### PR TITLE
PR for ticket# CS-18

### DIFF
--- a/app/Http/Controllers/Api/v1/TreeController.php
+++ b/app/Http/Controllers/Api/v1/TreeController.php
@@ -4,19 +4,10 @@ namespace App\Http\Controllers\Api\v1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\TreeStoreRequest;
-use CampService;
 use TreeService;
 use TreeRepository;
 use DateTimeHelper;
-use TopicService;
 use App\Http\Resources\TreeResource;
-use App\Exceptions\Camp\CampTreeException;
-use App\Exceptions\Camp\CampURLException;
-use App\Exceptions\Camp\CampDetailsException;
-use App\Exceptions\Camp\CampSupportCountException;
-use App\Exceptions\Camp\CampTreeCountException;
-use AlgorithmService;
-use Illuminate\Support\Facades\Log;
 
 class TreeController extends Controller
 {
@@ -36,24 +27,7 @@ class TreeController extends Controller
         $asOfTime = $request->input('asofdate');
         $updateAll = $request->input('update_all', 0);
 
-        $algorithms =  AlgorithmService::getCacheAlgorithms($updateAll, $algorithm);
-
-        foreach ($algorithms as $algo) {
-            try {
-
-                $tree = CampService::prepareCampTree($algo, $topicNumber, $asOfTime);
-                $topic = TopicService::getLiveTopic($topicNumber, $asOfTime, ['nofilter' => false]);
-
-                //get date string from timestamp
-                $asOfDate = DateTimeHelper::getAsOfDate($request);
-                $mongoArr = TreeService::prepareMongoArr($tree, $topic, $request, $asOfDate, $algo);
-                $conditions =  TreeService::getConditions($topicNumber, $algo, $asOfDate);
-            } catch (CampTreeException | CampDetailsException | CampTreeCountException | CampSupportCountException | CampURLException | \Exception $th) {
-                return ["data" => [], "code" => 401, "success" => false, "error" => $th->getMessage()];
-            }
-
-            $tree = TreeRepository::upsertTree($mongoArr, $conditions);
-        }
+        $tree =  TreeService::upsertTree($topicNumber, $algorithm, $asOfTime, $updateAll, $request);
 
         return new TreeResource(array($tree));
     }
@@ -71,10 +45,17 @@ class TreeController extends Controller
         /* get input params from request */
         $topicNumber = $request->input('topic_num');
         $algorithm = $request->input('algorithm');
+        $asOfTime = $request->input('asofdate');
+        $updateAll = $request->input('update_all', 0);
+        // get the tree from mongoDb
         $asOfDate =  DateTimeHelper::getAsOfDate($request);
-
         $conditions =  TreeService::getConditions($topicNumber, $algorithm, $asOfDate);
         $tree =  TreeRepository::findTree($conditions);
+
+        // create tree if not found
+        if($tree->isEmpty() || !$tree){
+           $tree =  array(TreeService::upsertTree($topicNumber, $algorithm, $asOfTime, $updateAll, $request));
+        }
 
         return new TreeResource($tree);
     }

--- a/app/Http/Resources/TreeResource.php
+++ b/app/Http/Resources/TreeResource.php
@@ -15,6 +15,11 @@ class TreeResource extends ResourceCollection
      */
     public function toArray($request)
     {
+        //if exception happen during the tree calculation
+        if (isset($this->collection[0]['code']) && $this->collection[0]['code'] == 401) {
+            return $this->collection[0];
+        }
+
         if (count($this->collection) > 0) {
             return ["data" => $this->collection, "code" => 200, "success" => true];
         }


### PR DESCRIPTION
An API will be created that will fetch the cached tree from MongoDB and return the JSON result. In case a cached tree is not available, the tree would be fetched directly from Tree Composer Engine (without any job).

Changes:
 made a common function which is used in store and get tree api
 change the resource class and add another condition if exception occur during tree calculation
 add updateAll parameter